### PR TITLE
Removing the filter param option for the discovery endpoints

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group "com.bettercloud"
-version "1.0.4-custom"
+version "1.0.5-custom"
 
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 

--- a/spring-boot-starter-scim2/src/main/java/com/bettercloud/scim2/server/controller/discovery/SchemaAwareController.java
+++ b/spring-boot-starter-scim2/src/main/java/com/bettercloud/scim2/server/controller/discovery/SchemaAwareController.java
@@ -44,20 +44,14 @@ public abstract class SchemaAwareController extends BaseResourceController<Gener
      * Service SCIM request to retrieve all resource types or schemas defined at the
      * service provider using GET.
      *
-     * @param filterString The filter string used to request a subset of resources.
-     *
      * @return All resource types in a ListResponse container.
      *
      * @throws ScimException If an error occurs.
      */
     @GetMapping
-    public ListResponse<GenericScimResource> search(
-            @RequestParam(value = ApiConstants.QUERY_PARAMETER_FILTER, required = false) final String filterString) throws ScimException {
+    public ListResponse<GenericScimResource> search() throws ScimException {
 
-        final List<GenericScimResource> filteredResources = StringUtils.isEmpty(filterString)
-                                                            ? resources
-                                                            : filterResources(Filter.fromString(filterString));
-        final List<GenericScimResource> preparedResources = genericScimResourceConverter.convert(null, null, filteredResources);
+        final List<GenericScimResource> preparedResources = genericScimResourceConverter.convert(null, null, resources);
 
         return new ListResponse<>(preparedResources.size(), preparedResources, 1, preparedResources.size());
     }

--- a/spring-boot-starter-scim2/src/test/java/com/bettercloud/scim2/server/controller/ResourceTypesControllerTest.java
+++ b/spring-boot-starter-scim2/src/test/java/com/bettercloud/scim2/server/controller/ResourceTypesControllerTest.java
@@ -23,7 +23,7 @@ public class ResourceTypesControllerTest {
 
     @Test
     public void search() throws ScimException {
-        final ListResponse<GenericScimResource> response = resourceTypesController.search(null);
+        final ListResponse<GenericScimResource> response = resourceTypesController.search();
         assertNotNull(response);
     }
 

--- a/spring-boot-starter-scim2/src/test/java/com/bettercloud/scim2/server/controller/SchemasControllerTest.java
+++ b/spring-boot-starter-scim2/src/test/java/com/bettercloud/scim2/server/controller/SchemasControllerTest.java
@@ -23,7 +23,7 @@ public class SchemasControllerTest {
 
     @Test
     public void search() throws ScimException {
-        final ListResponse<GenericScimResource> response = schemasController.search(null);
+        final ListResponse<GenericScimResource> response = schemasController.search();
         assertNotNull(response);
     }
 


### PR DESCRIPTION
Filter Query parameter should not be available in Swagger Page for "/v2/Schemas" and "/v2/ResourceTypes" endpoints